### PR TITLE
Fix method lookup and cleanup debug logs

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -24,7 +24,14 @@ function tryPaths(data, firstKey) {
 
 function tryWithProperty(pathData, property) {
   console.log("respi", property, pathData?.post?.[property]);
-  return pathData?.get?.[property] ?? pathData?.post?.[property] ?? pathData?.post?.[property] ?? null;
+  const methods = ["get", "post", "put", "patch", "delete"]; 
+  for (const method of methods) {
+    const value = pathData?.[method]?.[property];
+    if (value) {
+      return value;
+    }
+  }
+  return null;
 }
 
 function getMethod(data, firstKey) {

--- a/index.js
+++ b/index.js
@@ -96,7 +96,6 @@ module.exports = {
 
         let data;
         try {
-          console.log(markerContent.trim());
           data = JSON.parse(markerContent.trim());
         } catch (error) {
           console.error("Error parsing JSON for dynamic template:", error);
@@ -116,15 +115,14 @@ module.exports = {
 
         const { info, schemes, host, basePath, paths } = data;
         const { description, title } = info;
-        const path = Object.keys(paths ?? {})[0];
+        const endpointPath = Object.keys(paths ?? {})[0];
         const paramName = `${parameters?.name}`;
-        console.log("gugus", schema);
 
         const dynamicContent = template({
           apiTitle: title,
-          method: getMethod(data, "/{input}"),
+          method: getMethod(data, firstKey),
           baseUrl: schemes[0] + "://" + host + basePath,
-          path: path === "/" ? "" : `${path.replace("/", "")}`,
+          path: endpointPath === "/" ? "" : `${endpointPath.replace("/", "")}`,
           description: description,
           paramName: paramName,
           required: required ? "*" : "",


### PR DESCRIPTION
## Summary
- improve HTTP method lookup logic
- remove leftover debug logs and compute method using correct path

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840196df82083339a30e22b998076bd